### PR TITLE
Added UID control

### DIFF
--- a/ics.js
+++ b/ics.js
@@ -21,6 +21,8 @@ var ics = function(uidDomain, prodId) {
   ].join(SEPARATOR);
   var calendarEnd = SEPARATOR + 'END:VCALENDAR';
   var BYDAY_VALUES = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'];
+  var uid = ''; // a holder for the UID parameter for each event
+  var uid_from_title_and_dates = false; // should we create a new UID from the title arg?
 
   return {
     /**
@@ -37,6 +39,43 @@ var ics = function(uidDomain, prodId) {
      */
     'calendar': function() {
       return calendarStart + SEPARATOR + calendarEvents.join(SEPARATOR) + calendarEnd;
+    },
+    
+    /**
+     * Sets this.uid to be a passed argument
+     * @param {string} newUID  The UID to store
+     */
+    'setUID': function(newUID) {
+      this.uid = newUID;
+      
+      // if we have both the autoUID and setUID, we need to allow the more specific to have higher precedence
+      this.uid_from_title_and_dates = false;
+    },
+    
+    /**
+     * Retrieves this.uid if it's set, otherwise it grabs the title and dates or the default uid depending on the this.uid_from_title flag
+     * @param {string} [title_and_dates=]
+     * @param {string} [default_uid=]
+     */
+     'getUID': function(title_and_dates = '', default_uid = '') {
+    
+        if (this.uid_from_title_and_dates) {
+          return title_and_dates;
+        }
+
+        if (this.uid != undefined && this.uid != '') {
+          return this.uid;
+        }
+  
+        return default_uid;
+     },
+    
+    /**
+     * Sets the this.uid_from_title_and_dates flag which allows a new UID for each event generated from the title of the event
+     * @param {boolean}
+     */
+    'autoUID': function(bool) {
+      this.uid_from_title_and_dates = bool;
     },
 
     /**
@@ -176,7 +215,7 @@ var ics = function(uidDomain, prodId) {
 
       var calendarEvent = [
         'BEGIN:VEVENT',
-        'UID:' + calendarEvents.length + "@" + uidDomain,
+        'UID:' + this.getUID(subject+now+start+end, calendarEvents.length + "@" + uidDomain),
         'CLASS:PUBLIC',
         'DESCRIPTION:' + description,
         'DTSTAMP;VALUE=DATE-TIME:' + now,


### PR DESCRIPTION
Apple Calendar and Google Calendar both have an issue if you download and add multiple calendars with the same UID and it will, randomly, overwrite data with each.  This patch adds 3 new functions:
.setUID(str)
.autoUID(bool)
.getUID(event_title, default)

This allows for each event to have a unique ID.  setUID has the highest precedence so you can use a custom hashing function, if desired, or any other manual modification to the UID.  This should be run before addEvent.  The autoUID may be set as well to allow for multiple events to have automatic UIDs based on their title and dates.